### PR TITLE
feat: auto-select best quality + show bitrate in download panel

### DIFF
--- a/internal/assets/inject/batch_download.js
+++ b/internal/assets/inject/batch_download.js
@@ -833,16 +833,24 @@ async function __batch_download_selected__() {
       var resolution = '';
       var width = 0, height = 0;
 
+      // 自动选择最佳画质
+      var bestSpec = null;
       if (video.spec && video.spec.length > 0) {
-        var firstSpec = video.spec[0];
-        width = firstSpec.width || 0;
-        height = firstSpec.height || 0;
+        bestSpec = window.__wx_pick_best_spec ? window.__wx_pick_best_spec(video.spec) : video.spec[0];
+        width = bestSpec.width || 0;
+        height = bestSpec.height || 0;
         resolution = width && height ? (width + 'x' + height) : '';
+      }
+
+      // 拼接画质参数到 URL（修复：原版未加 X-snsvideoflag，导致批量下载画质不确定）
+      var downloadUrl = video.url || '';
+      if (bestSpec && bestSpec.fileFormat && downloadUrl) {
+        downloadUrl += (downloadUrl.indexOf('?') >= 0 ? '&' : '?') + 'X-snsvideoflag=' + bestSpec.fileFormat;
       }
 
       return {
         id: video.id || '',
-        url: video.url || '',
+        url: downloadUrl,
         title: video.title || video.id || String(Date.now()),
         author: authorName,
         key: video.key || '',

--- a/internal/assets/inject/feed.js
+++ b/internal/assets/inject/feed.js
@@ -545,15 +545,17 @@ function __show_feed_download_options(profile) {
   // 选项区域
   html += '<div style="padding:16px 20px;">';
 
-  // 视频下载选项
+  // 视频下载选项（按画质排序，标注码率和推荐）
   if (profile.spec && profile.spec.length > 0) {
+    var sortedSpecs = window.__wx_sort_specs ? window.__wx_sort_specs(profile.spec, profile.size, profile.duration) : profile.spec;
+    profile._sortedSpecs = sortedSpecs;
     html += '<div style="margin-bottom:12px;font-size:12px;color:#999;">选择画质:</div>';
-    profile.spec.forEach(function (spec, index) {
-      var label = spec.fileFormat || ('画质' + (index + 1));
-      if (spec.width && spec.height) {
-        label += ' (' + spec.width + 'x' + spec.height + ')';
-      }
-      html += '<div class="download-option" data-index="' + index + '" style="padding:10px 16px;margin:8px 0;background:rgba(255,255,255,0.08);border-radius:6px;cursor:pointer;text-align:center;transition:background 0.2s;font-size:13px;">' + label + '</div>';
+    sortedSpecs.forEach(function (spec, index) {
+      var label = window.__wx_spec_label ? window.__wx_spec_label(spec) : (spec.fileFormat || ('画质' + (index + 1)));
+      var bgColor = spec.isBest ? 'rgba(7,193,96,0.15)' : 'rgba(255,255,255,0.08)';
+      var textColor = spec.isBest ? '#07c160' : '#e5e5e5';
+      var extraStyle = spec.isBest ? 'border:1px solid rgba(7,193,96,0.3);font-weight:500;' : '';
+      html += '<div class="download-option" data-index="' + index + '" data-sorted="true" style="padding:10px 16px;margin:8px 0;background:' + bgColor + ';color:' + textColor + ';border-radius:6px;cursor:pointer;text-align:center;transition:background 0.2s;font-size:13px;' + extraStyle + '">' + label + '</div>';
     });
   } else {
     html += '<div class="download-option" data-index="-1" style="padding:10px 16px;margin:8px 0;background:rgba(255,255,255,0.08);border-radius:6px;cursor:pointer;text-align:center;font-size:13px;">下载视频</div>';
@@ -602,7 +604,9 @@ function __show_feed_download_options(profile) {
     el.onmouseout = function () { this.style.background = 'rgba(255,255,255,0.08)'; };
     el.onclick = function () {
       var index = parseInt(this.getAttribute('data-index'));
-      var spec = index >= 0 && profile.spec ? profile.spec[index] : null;
+      var isSorted = this.getAttribute('data-sorted') === 'true';
+      var specArr = isSorted && profile._sortedSpecs ? profile._sortedSpecs : profile.spec;
+      var spec = index >= 0 && specArr ? specArr[index] : null;
       closeMenu();
       __wx_channels_handle_click_download__(spec);
     };

--- a/internal/assets/inject/home.js
+++ b/internal/assets/inject/home.js
@@ -684,15 +684,18 @@ function __show_home_download_options(profile) {
   // 选项区域
   html += '<div style="padding:16px 20px;">';
 
-  // 视频下载选项
+  // 视频下载选项（按画质排序，标注码率和推荐）
   if (profile.spec && profile.spec.length > 0) {
+    var sortedSpecs = window.__wx_sort_specs ? window.__wx_sort_specs(profile.spec, profile.size, profile.duration) : profile.spec;
+    // 保存排序后的 spec 到 profile 供点击时使用
+    profile._sortedSpecs = sortedSpecs;
     html += '<div style="margin-bottom:12px;font-size:12px;color:#999;">选择画质:</div>';
-    profile.spec.forEach(function (spec, index) {
-      var label = spec.fileFormat || ('画质' + (index + 1));
-      if (spec.width && spec.height) {
-        label += ' (' + spec.width + 'x' + spec.height + ')';
-      }
-      html += '<div class="download-option" data-index="' + index + '" style="padding:10px 16px;margin:8px 0;background:rgba(255,255,255,0.08);border-radius:6px;cursor:pointer;text-align:center;transition:background 0.2s;font-size:13px;">' + label + '</div>';
+    sortedSpecs.forEach(function (spec, index) {
+      var label = window.__wx_spec_label ? window.__wx_spec_label(spec) : (spec.fileFormat || ('画质' + (index + 1)));
+      var bgColor = spec.isBest ? 'rgba(7,193,96,0.15)' : 'rgba(255,255,255,0.08)';
+      var textColor = spec.isBest ? '#07c160' : '#e5e5e5';
+      var extraStyle = spec.isBest ? 'border:1px solid rgba(7,193,96,0.3);font-weight:500;' : '';
+      html += '<div class="download-option" data-index="' + index + '" data-sorted="true" style="padding:10px 16px;margin:8px 0;background:' + bgColor + ';color:' + textColor + ';border-radius:6px;cursor:pointer;text-align:center;transition:background 0.2s;font-size:13px;' + extraStyle + '">' + label + '</div>';
     });
   } else {
     html += '<div class="download-option" data-index="-1" style="padding:10px 16px;margin:8px 0;background:rgba(255,255,255,0.08);border-radius:6px;cursor:pointer;text-align:center;font-size:13px;">下载视频</div>';
@@ -743,7 +746,9 @@ function __show_home_download_options(profile) {
     el.onmouseout = function () { this.style.background = 'rgba(255,255,255,0.08)'; };
     el.onclick = function () {
       var index = parseInt(this.getAttribute('data-index'));
-      var spec = index >= 0 && profile.spec ? profile.spec[index] : null;
+      var isSorted = this.getAttribute('data-sorted') === 'true';
+      var specArr = isSorted && profile._sortedSpecs ? profile._sortedSpecs : profile.spec;
+      var spec = index >= 0 && specArr ? specArr[index] : null;
       closeMenu();
       __wx_channels_handle_click_download__(spec);
     };

--- a/internal/assets/inject/utils.js
+++ b/internal/assets/inject/utils.js
@@ -219,6 +219,96 @@ var WXU = (() => {
     return null;
   }
 
+  // ==================== 画质排序与码率估算 ====================
+
+  /**
+   * 按像素数降序排列 spec，返回排序后的副本（不修改原数组）。
+   * 每个 spec 会被增强：添加 pixels, estSize, estBitrate, isBest 字段。
+   * @param {Array} specArr - 原始 spec 数组
+   * @param {number} totalSize - 视频总大小 (bytes)，来自 media.fileSize
+   * @param {number} durationMs - 视频时长 (ms)
+   * @returns {Array} 排序后的 spec 数组
+   */
+  function __wx_sort_specs(specArr, totalSize, durationMs) {
+    if (!specArr || specArr.length === 0) return [];
+    var sorted = specArr.slice().map(function(s) {
+      return Object.assign({}, s, {
+        pixels: (s.width || 0) * (s.height || 0)
+      });
+    });
+    sorted.sort(function(a, b) { return b.pixels - a.pixels; });
+
+    // 估算各画质文件大小和码率
+    var maxPixels = sorted[0].pixels || 1;
+    var durationSec = (durationMs || 1) / 1000;
+    sorted.forEach(function(s, i) {
+      var ratio = s.pixels > 0 ? s.pixels / maxPixels : 0.5;
+      // 粗估：按像素比例缩放总大小（实际编码不完全线性，但足够参考）
+      s.estSize = totalSize ? Math.round(totalSize * ratio) : 0;
+      s.estBitrate = s.estSize > 0 ? Math.round(s.estSize * 8 / durationSec) : 0;
+      s.isBest = (i === 0);
+    });
+    return sorted;
+  }
+
+  /**
+   * 选出最佳画质 spec（像素数最大）
+   */
+  function __wx_pick_best_spec(specArr) {
+    if (!specArr || specArr.length === 0) return null;
+    var best = specArr[0];
+    var bestPixels = (best.width || 0) * (best.height || 0);
+    for (var i = 1; i < specArr.length; i++) {
+      var px = (specArr[i].width || 0) * (specArr[i].height || 0);
+      if (px > bestPixels) {
+        best = specArr[i];
+        bestPixels = px;
+      }
+    }
+    return best;
+  }
+
+  /**
+   * 格式化文件大小为可读字符串
+   */
+  function __wx_format_size(bytes) {
+    if (!bytes || bytes <= 0) return '';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(0) + 'KB';
+    return (bytes / (1024 * 1024)).toFixed(1) + 'MB';
+  }
+
+  /**
+   * 格式化码率为可读字符串
+   */
+  function __wx_format_bitrate(bps) {
+    if (!bps || bps <= 0) return '';
+    if (bps < 1000000) return (bps / 1000).toFixed(0) + 'Kbps';
+    return (bps / 1000000).toFixed(1) + 'Mbps';
+  }
+
+  /**
+   * 生成画质选项的显示标签（含分辨率、估算大小、码率）
+   */
+  function __wx_spec_label(spec) {
+    var label = spec.fileFormat || '未知';
+    if (spec.width && spec.height) {
+      label += ' (' + spec.width + 'x' + spec.height + ')';
+    }
+    var extras = [];
+    if (spec.estSize > 0) extras.push('~' + __wx_format_size(spec.estSize));
+    if (spec.estBitrate > 0) extras.push(__wx_format_bitrate(spec.estBitrate));
+    if (extras.length > 0) label += ' ' + extras.join(' ');
+    if (spec.isBest) label += ' ★';
+    return label;
+  }
+
+  // 暴露到全局
+  window.__wx_sort_specs = __wx_sort_specs;
+  window.__wx_pick_best_spec = __wx_pick_best_spec;
+  window.__wx_spec_label = __wx_spec_label;
+  window.__wx_format_size = __wx_format_size;
+  window.__wx_format_bitrate = __wx_format_bitrate;
+
   function __wx_channels_copy(text) {
     var textArea = document.createElement("textarea");
     textArea.value = text;


### PR DESCRIPTION
## Summary

- Sort quality options by resolution (highest first), highlight best with ★ green marker
- Show estimated file size and bitrate per quality tier in the download dropdown
- **Fix batch download**: auto-select highest quality + append missing `X-snsvideoflag` parameter

## Problem

- Users reported downloads were "compressed" (#47) and couldn't get "original quality" (#49)
- Root cause: batch download JS never appended `X-snsvideoflag` to CDN URL, so WeChat CDN returned default (lower) quality
- Single-video dropdown showed unsorted quality options with no size/bitrate info

## Changes

| File | Change |
|---|---|
| `inject/utils.js` | New: `__wx_sort_specs()`, `__wx_pick_best_spec()`, `__wx_spec_label()` + size/bitrate formatting |
| `inject/home.js` | Sorted dropdown with rich labels, green ★ best marker |
| `inject/feed.js` | Same as home.js for feed/detail page |
| `inject/batch_download.js` | Auto-select best spec + fix missing `X-snsvideoflag` in batch URL |

## Before / After

**Before**: `xWT111 (720x1280)` — no size, no bitrate, unsorted
**After**: `xWT111 (720x1280) ~3.2MB 1.2Mbps ★` — sorted, estimated metrics, best highlighted

## Test plan

- [x] Download panel shows sorted quality options with size/bitrate estimates
- [x] Best quality highlighted in green with ★
- [x] Click best option → downloads correct quality
- [x] Batch download uses highest quality with correct `X-snsvideoflag`

Closes #47, Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)